### PR TITLE
Use valid version in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP32_LoRaWAN
-version=Internal RTC2.0
+version=2.0
 author=HelTec
 maintainer=Harry <harry@heltec.cn>
 sentence=LoRaWAN library for ESP32 + LoRa boards made by heltec


### PR DESCRIPTION
The previous version value caused the Arduino IDE to repeatedly display warnings:

Invalid version 'Internal RTC2.0' for library in: E:\arduino\libraries\ESP32_LoRaWAN

In previous versions of the Arduino IDE, the library path was not shown in the warning, which made it especially confusing to the users.

Installing a library with an invalid version causes Arduino IDE 1.8.6 to no longer start.

A semver-ish version format is required.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format

Originally reported at:
http://forum.arduino.cc/index.php?topic=596113