### PR TITLE
Fixed some compile errors/warnings

### DIFF
--- a/src/LoRaMac.c
+++ b/src/LoRaMac.c
@@ -746,7 +746,6 @@ static void PrepareRxDoneAbort( void )
 
 void OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr )
 {
-	uint8_t * temp = payload;
     LoRaMacHeader_t macHdr;
     LoRaMacFrameCtrl_t fCtrl;
     ApplyCFListParams_t applyCFList;

--- a/src/board.c
+++ b/src/board.c
@@ -24,48 +24,7 @@ Maintainer: Miguel Luis and Gregory Cristian
 Uart_t UartUsb;
 #endif
 
-/*!
-* Initializes the unused GPIO to a know status
-*/
-static void BoardUnusedIoInit( void );
 
-/*!
-* System Clock Configuration
-*/
-static void SystemClockConfig( void );
-
-/*!
-* Used to measure and calibrate the system wake-up time from STOP mode
-*/
-static void CalibrateSystemWakeupTime( void );
-
-/*!
-* System Clock Re-Configuration when waking up from STOP mode
-*/
-static void SystemClockReConfig( void );
-
-/*!
-* Timer used at first boot to calibrate the SystemWakeupTime
-*/
-static TimerEvent_t CalibrateSystemWakeupTimeTimer;
-
-/*!
-* Flag to indicate if the MCU is Initialized
-*/
-static bool McuInitialized = false;
-
-/*!
-* Flag to indicate if the SystemWakeupTime is Calibrated
-*/
-static bool SystemWakeupTimeCalibrated = false;
-
-/*!
-* Callback indicating the end of the system wake-up time calibration
-*/
-static void OnCalibrateSystemWakeupTimeTimerEvent( void )
-{
-  SystemWakeupTimeCalibrated = true;
-}
 
 /*!
 * Nested interrupt counter.
@@ -90,7 +49,7 @@ void BoardEnableIrq( void )
 }
 
 void BoardInitPeriph( void )
-{  
+{
 
 }
 
@@ -140,7 +99,7 @@ uint16_t BoardBatteryMeasureVolage( void )
   //    uint16_t vref = VREFINT_CAL;
   //    uint16_t vdiv = 0;
   uint16_t batteryVoltage = 0;
-  
+
   //    vdiv = AdcReadChannel( &Adc, BAT_LEVEL_CHANNEL );
   //    //vref = AdcReadChannel( &Adc, ADC_CHANNEL_VREFINT );
   //
@@ -163,34 +122,6 @@ uint8_t BoardGetBatteryLevel( void )
   return 0;
 }
 
-static void BoardUnusedIoInit( void )
-{
-
-}
-
-void SystemClockConfig( void )
-{
-  
-}
-
-void CalibrateSystemWakeupTime( void )
-{
-  if( SystemWakeupTimeCalibrated == false )
-  {
-    TimerInit( &CalibrateSystemWakeupTimeTimer, OnCalibrateSystemWakeupTimeTimerEvent );
-    TimerSetValue( &CalibrateSystemWakeupTimeTimer, 1000 );
-    TimerStart( &CalibrateSystemWakeupTimeTimer );
-    while( SystemWakeupTimeCalibrated == false )
-    {
-      TimerLowPowerHandler( );
-    }
-  }
-}
-
-void SystemClockReConfig( void )
-{
-
-}
 
 void SysTick_Handler( void )
 {
@@ -213,33 +144,6 @@ uint8_t GetBoardPowerSource( void )
 #endif
 }
 
-uint32_t HexToString(/*IN*/  const char    * pHex,  
-                     /*IN*/  uint32_t           hexLen,  
-                     /*OUT*/ char          * pByteString)  
-{  
-  unsigned long i;  
-  
-  if (pHex==NULL)  
-    return 1;  
-  
-  if(hexLen <= 0)  
-    return 2;  
-  
-  for(i=0;i<hexLen;i++)  
-  {  
-    if(((pHex[i]&0xf0)>>4)>=0 && ((pHex[i]&0xf0)>>4)<=9)  
-      pByteString[2*i]=((pHex[i]&0xf0)>>4)+0x30;  
-    else if(((pHex[i]&0xf0)>>4)>=10 && ((pHex[i]&0xf0)>>4)<=16)  
-      pByteString[2*i]=((pHex[i]&0xf0)>>4)+0x37;   //  小写：0x37 改为 0x57   
-    
-    if((pHex[i]&0x0f)>=0 && (pHex[i]&0x0f)<=9)  
-      pByteString[2*i+1]=(pHex[i]&0x0f)+0x30;  
-    else if((pHex[i]&0x0f)>=10 && (pHex[i]&0x0f)<=16)  
-      pByteString[2*i+1]=(pHex[i]&0x0f)+0x37;      //  小写：0x37 改为 0x57   
-  }  
-  return 0;  
-} 
-
 #ifdef USE_FULL_ASSERT
 /*
 * Function Name  : assert_failed
@@ -254,7 +158,7 @@ void assert_failed( uint8_t* file, uint32_t line )
 {
   /* User can add his own implementation to report the file name and line number,
   ex: printf("Wrong parameters value: file %s on line %d\r\n", file, line) */
-  
+
   /* Infinite loop */
   while( 1 )
   {

--- a/src/gpio-board.c
+++ b/src/gpio-board.c
@@ -28,7 +28,6 @@
 #endif
 
 
-static GpioIrqHandler *GpioIrq[16];
 
 void GpioMcuInit( Gpio_t *obj, uint8_t pin, uint8_t mode, PinConfigs config, PinTypes type, uint32_t value )
 {

--- a/src/region/RegionAU915.c
+++ b/src/region/RegionAU915.c
@@ -415,7 +415,8 @@ void RegionAU915ApplyCFList( ApplyCFListParams_t* applyCFList )
 
 bool RegionAU915ChanMaskSet( ChanMaskSetParams_t* chanMaskSet )
 {
-    uint8_t nbChannels = RegionCommonCountChannels( chanMaskSet->ChannelsMaskIn, 0, 4 );
+    //uint8_t nbChannels =
+    RegionCommonCountChannels( chanMaskSet->ChannelsMaskIn, 0, 4 );
 
     // Check the number of active channels
     // According to ACMA regulation, we require at least 20 125KHz channels, if

--- a/src/region/RegionLA915.c
+++ b/src/region/RegionLA915.c
@@ -498,7 +498,8 @@ void RegionLA915ApplyCFList( ApplyCFListParams_t* applyCFList )
 
 bool RegionLA915ChanMaskSet( ChanMaskSetParams_t* chanMaskSet )
 {
-    uint8_t nbChannels = RegionCommonCountChannels( chanMaskSet->ChannelsMaskIn, 0, 4 );
+    //uint8_t nbChannels =
+    RegionCommonCountChannels( chanMaskSet->ChannelsMaskIn, 0, 4 );
 
     // Check the number of active channels
     // According to ACMA regulation, we require at least 20 125KHz channels, if
@@ -929,7 +930,6 @@ bool RegionLA915NextChannel( NextChanParams_t* nextChanParams, uint8_t* channel,
     uint8_t delayTx = 0;
     uint8_t enabledChannels[LA915_MAX_NB_CHANNELS] = { 0 };
     TimerTime_t nextTxDelay = 0;
-    uint16_t random;
 
     // Count 125kHz channels
     if( RegionCommonCountChannels( ChannelsMaskRemaining, 0, 4 ) == 0 )
@@ -964,8 +964,6 @@ bool RegionLA915NextChannel( NextChanParams_t* nextChanParams, uint8_t* channel,
     if( nbEnabledChannels > 0 )
     {
         // We found a valid channel
-       
-        random = randr( 0, nbEnabledChannels - 1 );
         *channel = enabledChannels[randr( 0, nbEnabledChannels - 1 )];
         // Disable the channel in the mask
         RegionCommonChanDisable( ChannelsMaskRemaining, *channel, LA915_MAX_NB_CHANNELS - 8 );


### PR DESCRIPTION
Hi,

this lib does not compiles with little stricter compile flags.
Since I have to use these flags, I have fixed the code, and propose this pr:

```
ESP32_LoRaWAN/src/gpio-board.c:31:24: error: 'GpioIrq' defined but not used [-Werror=unused-variable]
ESP32_LoRaWAN/src/board.c:190:6: error: 'SystemClockReConfig' defined but not used [-Werror=unused-function]
ESP32_LoRaWAN/src/board.c:176:6: error: 'CalibrateSystemWakeupTime' defined but not used [-Werror=unused-function]
ESP32_LoRaWAN/src/board.c:171:6: error: 'SystemClockConfig' defined but not used [-Werror=unused-function]
ESP32_LoRaWAN/src/board.c:166:13: error: 'BoardUnusedIoInit' defined but not used [-Werror=unused-function]
ESP32_LoRaWAN/src/board.c:55:13: error: 'McuInitialized' defined but not used [-Werror=unused-variable]
ESP32_LoRaWAN/src/region/RegionAU915.c:418:5: error: 'nbChannels' defined but not used [-Werror=unused-variable]
ESP32_LoRaWAN/src/region/RegionLA915.c:932:14: error: variable 'random' set but not used [-Werror=unused-but-set-variable]
ESP32_LoRaWAN/src/region/RegionLA915.c:501:13: error: unused variable 'nbChannels' [-Werror=unused-variable]
ESP32_LoRaWAN/src/LoRaMac.c:749:12: error: unused variable 'temp' [-Werror=unused-variable]
ESP32_LoRaWAN/src/board.c:50:21: error: 'CalibrateSystemWakeupTimeTimer' defined but not used [-Werror=unused-variable]
ESP32_LoRaWAN/src/board.c:50:21: error: 'CalibrateSystemWakeupTimeTimer' defined but not used [-Werror=unused-variable]
ESP32_LoRaWAN/src/board.c:60:13: error: 'SystemWakeupTimeCalibrated' defined but not used [-Werror=unused-variable]
```

Regards
