### PR TITLE
Mcu.init() problem solved and LORAWAN_PREAMBLE_LENGTH

### DIFF
--- a/src/LoRaMac.h
+++ b/src/LoRaMac.h
@@ -49,7 +49,7 @@
  */
 #ifndef __LORAMAC_H__
 #define __LORAMAC_H__
-
+#define LORAWAN_PREAMBLE_LENGTH 8 /*error with LORAWAN_PREAMBLE_LENGTH*/
 #include <stdint.h>
 #include <stdbool.h>
 #include "timer.h"

--- a/src/Mcu.S
+++ b/src/Mcu.S
@@ -84,6 +84,7 @@ _Z12writelicensev:
 .LCFI3:
 	.loc 1 32 0
 	call8	getLicenseAddress
+	retw.n
 .LVL3:
 	.loc 1 33 0
 	l32r	a11, .LC4


### PR DESCRIPTION
This pull tries to fix `LORAWAN_PREAMBLE_LENGTH` , it's set to `8` due to #87 
This pull also repairs `Mcu.S` because when you compile and upload code to your Heltec ESP32 LoraWan V2 it's in never-ending loop, mentioned in #91 
